### PR TITLE
fix: backport ReDoS fix from markdown-it in linkify inline parser (CVE-2026-2327)

### DIFF
--- a/src/rules/inline/linkify.ts
+++ b/src/rules/inline/linkify.ts
@@ -41,7 +41,14 @@ export default function linkify(state: StateInline, silent?: boolean): boolean {
     return false
 
   // disallow '*' at the end of the link (conflicts with emphasis)
-  url = url.replace(/\*+$/, '')
+  // do manual backsearch to avoid perf issues with regex /\*+$/ on "****...****a".
+  let urlEnd = url.length
+  while (urlEnd > 0 && url.charCodeAt(urlEnd - 1) === 0x2A/* * */) {
+    urlEnd--
+  }
+  if (urlEnd !== url.length) {
+    url = url.slice(0, urlEnd)
+  }
 
   const fullUrl = state.md.normalizeLink(url)
   if (!state.md.validateLink(fullUrl))

--- a/test/core/linkify.test.ts
+++ b/test/core/linkify.test.ts
@@ -25,4 +25,12 @@ describe('core linkify', () => {
     expect(href).toBeDefined()
     expect(href[1]).toContain('http://example.com')
   })
+
+  it('linkify trailing asterisks pattern (CVE-2026-2327)', () => {
+    const md = createMarkdownIt({ linkify: true })
+    // This pattern would cause ReDoS with the old regex implementation
+    // https://github.com/markdown-it/markdown-it/commit/4b4bbcae5e0990a5b172378e507b33a59012ed26
+    const result = md.render('https://test.com?' + '*'.repeat(70000) + 'a')
+    expect(result).toBeTruthy()
+  }, 500)
 })


### PR DESCRIPTION
- https://github.com/markdown-it/markdown-it/commit/4b4bbcae5e0990a5b172378e507b33a59012ed26
- https://github.com/markdown-it/markdown-it/blob/master/CHANGELOG.md#1411---2026-01-11
- https://github.com/advisories/GHSA-38c4-r59v-3vqw

This task takes more than 3 seconds:

```ts
import mdit from "markdown-exit";
mdit({linkify:true}).render("http://example.com/" + "*".repeat(70000) + "a");
```

due to the fact that the following expression

```ts
("*".repeat(1<<17) + " ").replace(/\*+$/, "")
```

ridiculously takes more than 10 seconds to be evaluated.

The patch was ported from the original markdown-it at the above commit and https://github.com/serkodev/markdown-exit/pull/25 with the help of Copilot (I don't think the content changes much even without using Copilot).