### PR TITLE
fix: backport ReDoS fix from markdown-it in linkify inline parser (CV…

### DIFF
--- a/src/rules/inline/linkify.ts
+++ b/src/rules/inline/linkify.ts
@@ -76,7 +76,14 @@ export default function linkify(state: StateInline, silent?: boolean): boolean {
     return false
 
   // disallow '*' at the end of the link (conflicts with emphasis)
-  url = url.replace(/\*+$/, '')
+  // Do manual backsearch to avoid perf issues with regex /\*+$/ on "****...****a".
+  let urlEnd = url.length
+  while (urlEnd > 0 && url.charCodeAt(urlEnd - 1) === 0x2A /* * */) {
+    urlEnd--
+  }
+  if (urlEnd !== url.length) {
+    url = url.slice(0, urlEnd)
+  }
 
   const fullUrl = state.md.normalizeLink(url)
   if (!state.md.validateLink(fullUrl))

--- a/test/core/linkify.test.ts
+++ b/test/core/linkify.test.ts
@@ -45,4 +45,12 @@ describe('core linkify', () => {
 
     expect(md.render(src)).toBe('<p>用户现在想要一个超链接到<a href="https://www.baidu.com">https://www.baidu.com</a></p>\n')
   })
+
+  it('linkify trailing asterisks pattern (CVE-2026-2327)', () => {
+    const md = createMarkdownIt({ linkify: true })
+    // This pattern would cause ReDoS with the old regex implementation.
+    // https://github.com/markdown-it/markdown-it/commit/4b4bbcae5e0990a5b172378e507b33a59012ed26
+    const result = md.render('https://test.com?' + '*'.repeat(70000) + 'a')
+    expect(result).toBeTruthy()
+  }, 500)
 })


### PR DESCRIPTION
…E-2026-2327)

Replace regex /\*+$/ with manual backsearch loop to avoid catastrophic
backtracking on inputs like "****...****a".

Ref: markdown-it/markdown-it@4b4bbca
Ref: GHSA-38c4-r59v-3vqw

Co-authored-by: tats-u <tats.u@live.jp>
Co-authored-by: Vitaly Puzrin <vitaly.puzrin@gmail.com>
(cherry picked from commit 9392fff)