### PR TITLE
Add delta-native stream parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "perf:compare": "node scripts/perf-compare.mjs docs/perf-latest.json",
     "perf:compare:ref": "node scripts/perf-compare-ref.mjs",
     "perf:compare:stream-ref": "node scripts/perf-stream-incremental-ref.mjs",
+    "perf:ai-stream": "npm run build && node scripts/perf-ai-stream-delta.mjs",
     "perf:check": "node scripts/perf-check.mjs --threshold=0.10",
     "perf:check:latest": "node scripts/perf-check.mjs --threshold=0.10 --latest",
     "perf:check:strict": "node scripts/perf-check.mjs --threshold=0.03 --latest",

--- a/scripts/perf-ai-stream-delta.mjs
+++ b/scripts/perf-ai-stream-delta.mjs
@@ -1,0 +1,102 @@
+import { performance } from 'node:perf_hooks'
+import MarkdownIt from '../dist/index.js'
+import { createDeltaStream, StreamBuffer } from '../dist/experimental.js'
+
+function makeDoc(repeats) {
+  let out = ''
+  for (let i = 0; i < repeats; i++) {
+    out += `Paragraph ${i} with **bold** text and inline code.\n\n`
+    if (i % 12 === 0) {
+      out += '```ts\n'
+      out += `const value${i} = ${i}\n`
+      out += '```\n\n'
+    }
+  }
+  return out
+}
+
+function splitDeltas(src, size) {
+  const chunks = []
+  for (let i = 0; i < src.length; i += size)
+    chunks.push(src.slice(i, i + size))
+  return chunks
+}
+
+function timeScenario(name, run) {
+  const samples = []
+  const start = performance.now()
+  const result = run((sample) => samples.push(sample))
+  const totalMs = performance.now() - start
+  samples.sort((a, b) => a - b)
+  const p50 = samples[Math.floor(samples.length * 0.5)] ?? 0
+  const p95 = samples[Math.floor(samples.length * 0.95)] ?? 0
+  return {
+    scenario: name,
+    totalMs,
+    p50ChunkMs: p50,
+    p95ChunkMs: p95,
+    maxChunkMs: samples[samples.length - 1] ?? 0,
+    ...result,
+  }
+}
+
+const src = makeDoc(800)
+const deltas = splitDeltas(src, 48)
+
+const results = [
+  timeScenario('full-render-growing-string', (sample) => {
+    const md = MarkdownIt()
+    let text = ''
+    for (const delta of deltas) {
+      text += delta
+      const start = performance.now()
+      md.render(text)
+      sample(performance.now() - start)
+    }
+    return {}
+  }),
+  timeScenario('stream-buffer-boundary', (sample) => {
+    const md = MarkdownIt({ stream: true })
+    const buffer = new StreamBuffer(md)
+    for (const delta of deltas) {
+      buffer.feed(delta)
+      const start = performance.now()
+      buffer.flushIfBoundary()
+      sample(performance.now() - start)
+    }
+    const start = performance.now()
+    buffer.flushForce()
+    sample(performance.now() - start)
+    return md.stream.stats()
+  }),
+  timeScenario('stream-parse-growing-string', (sample) => {
+    const md = MarkdownIt({ stream: true })
+    let text = ''
+    for (const delta of deltas) {
+      text += delta
+      const start = performance.now()
+      md.stream.parse(text)
+      sample(performance.now() - start)
+    }
+    return md.stream.stats()
+  }),
+  timeScenario('delta-native', (sample) => {
+    const md = MarkdownIt({ stream: true })
+    const stream = createDeltaStream(md)
+    for (const delta of deltas) {
+      const start = performance.now()
+      stream.feed(delta)
+      sample(performance.now() - start)
+    }
+    const start = performance.now()
+    stream.flush({ final: true })
+    sample(performance.now() - start)
+    return stream.stats()
+  }),
+]
+
+console.log(JSON.stringify({
+  chars: src.length,
+  deltas: deltas.length,
+  results,
+}, null, 2))

--- a/src/experimental.ts
+++ b/src/experimental.ts
@@ -17,6 +17,9 @@ export type { ChunkedOptions, ChunkRange } from './stream/chunked'
 
 export { DebouncedStreamParser, ThrottledStreamParser } from './stream/debounced'
 
+export { createDeltaStream, DeltaMarkdownStream } from './stream/delta'
+export type { DeltaMarkdownStreamOptions, DeltaMarkdownStreamStats, StreamPatch } from './stream/delta'
+
 export { EditableBuffer } from './stream/editable'
 export type { EditableBufferStats } from './stream/editable'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import defaultPreset from './presets/default'
 import zeroPreset from './presets/zero'
 import Renderer from './render/renderer'
 import { chunkedParse } from './stream/chunked'
+import { DeltaMarkdownStream } from './stream/delta'
 import { StreamParser } from './stream/parser'
 import {
   getAutoUnboundedDecision,
@@ -173,6 +174,7 @@ export interface MarkdownIt {
     peek: () => TokenType[]
     stats: () => StreamStats
     resetStats: () => void
+    createDelta: (env?: Record<string, unknown>) => DeltaMarkdownStream
   }
   set: (options: MarkdownItOptions) => this
   configure: (presets: string | Preset) => this
@@ -762,6 +764,9 @@ function markdownIt(presetName?: string | MarkdownItOptions, options?: MarkdownI
     resetStats() {
       if (streamParser)
         streamParser.resetStats()
+    },
+    createDelta(env: Record<string, unknown> = {}) {
+      return new DeltaMarkdownStream(md as MarkdownIt, env)
     },
   }
 

--- a/src/parse/parser_block/state_block.ts
+++ b/src/parse/parser_block/state_block.ts
@@ -50,6 +50,21 @@ export class StateBlock {
     let offset = 0
     let start = 0
     let indent_found = false
+    let line = 0
+
+    if (typeof s === 'string' && s.length > 0) {
+      let markerCount = s.charCodeAt(s.length - 1) === 0x0A ? 0 : 1
+      for (let i = 0; i < s.length; i++) {
+        if (s.charCodeAt(i) === 0x0A)
+          markerCount++
+      }
+
+      this.bMarks = new Array(markerCount + 1)
+      this.eMarks = new Array(markerCount + 1)
+      this.tShift = new Array(markerCount + 1)
+      this.sCount = new Array(markerCount + 1)
+      this.bsCount = new Array(markerCount + 1)
+    }
 
     for (let pos = 0, len = s.length; pos < len; pos++) {
       const ch = s.charCodeAt(pos)
@@ -73,11 +88,12 @@ export class StateBlock {
       if (ch === 0x0A || pos === len - 1) {
         if (ch !== 0x0A)
           pos++
-        this.bMarks.push(start)
-        this.eMarks.push(pos)
-        this.tShift.push(indent)
-        this.sCount.push(offset)
-        this.bsCount.push(0)
+        this.bMarks[line] = start
+        this.eMarks[line] = pos
+        this.tShift[line] = indent
+        this.sCount[line] = offset
+        this.bsCount[line] = 0
+        line++
 
         indent_found = false
         indent = 0
@@ -87,13 +103,13 @@ export class StateBlock {
     }
 
     // Push fake entry to simplify bounds checks
-    this.bMarks.push(s.length)
-    this.eMarks.push(s.length)
-    this.tShift.push(0)
-    this.sCount.push(0)
-    this.bsCount.push(0)
+    this.bMarks[line] = s.length
+    this.eMarks[line] = s.length
+    this.tShift[line] = 0
+    this.sCount[line] = 0
+    this.bsCount[line] = 0
 
-    this.lineMax = this.bMarks.length - 1
+    this.lineMax = line
   }
 
   push(type: string, tag: string, nesting: number): Token {

--- a/src/parse/parser_inline/index.ts
+++ b/src/parse/parser_inline/index.ts
@@ -54,6 +54,26 @@ function isInlineTerminatorChar(ch: number): boolean {
   }
 }
 
+function isDefaultDispatchChar(ch: number, linkifyEnabled: boolean): boolean {
+  switch (ch) {
+    case 0x0A: // \n
+    case 0x21: // !
+    case 0x26: // &
+    case 0x2A: // *
+    case 0x3C: // <
+    case 0x5B: // [
+    case 0x5C: // \
+    case 0x5F: // _
+    case 0x60: // `
+    case 0x7E: // ~
+      return true
+    case 0x3A: // :
+      return linkifyEnabled
+    default:
+      return false
+  }
+}
+
 export function isPlainInlineText(src: string): boolean {
   for (let i = 0; i < src.length; i++) {
     if (isInlineTerminatorChar(src.charCodeAt(i))) {
@@ -193,6 +213,11 @@ export class ParserInline {
     const shouldProfile = !!state.env && (Object.prototype.hasOwnProperty.call(state.env, '__mdtsRuleProfile') || Object.prototype.hasOwnProperty.call(state.env, '__mdtsProfileRules'))
 
     if (!shouldProfile) {
+      if (typeof state.src === 'string' && this.isDefaultRuleset()) {
+        this.tokenizeDefault(state)
+        return
+      }
+
       while (state.pos < end) {
         const prevPos = state.pos
         let ok: boolean | void = false
@@ -260,6 +285,69 @@ export class ParserInline {
 
     if (state.pending) {
       state.pushPending()
+    }
+  }
+
+  private tokenizeDefault(state: StateInline): void {
+    const src = state.src as string
+    const end = state.posMax
+    const linkifyEnabled = !!state.md.options.linkify
+
+    while (state.pos < end) {
+      const prevPos = state.pos
+      const ch = src.charCodeAt(prevPos)
+
+      if (!isDefaultDispatchChar(ch, linkifyEnabled)) {
+        let pos = prevPos + 1
+        while (pos < end && !isDefaultDispatchChar(src.charCodeAt(pos), linkifyEnabled))
+          pos++
+        state.pending += src.slice(prevPos, pos)
+        state.pos = pos
+        continue
+      }
+
+      let ok: boolean | void = false
+      if (state.level < state.maxNesting)
+        ok = this.tryDefaultRule(state, ch)
+
+      if (ok) {
+        if (prevPos >= state.pos)
+          throw new Error('inline rule didn\'t increment state.pos')
+        continue
+      }
+
+      state.pending += src.charAt(state.pos++)
+    }
+
+    if (state.pending)
+      state.pushPending()
+  }
+
+  private tryDefaultRule(state: StateInline, ch: number): boolean | void {
+    switch (ch) {
+      case 0x0A:
+        return newline(state, false)
+      case 0x21:
+        return image(state, false)
+      case 0x26:
+        return entity(state, false)
+      case 0x2A:
+      case 0x5F:
+        return emphasis.tokenize(state, false)
+      case 0x3A:
+        return linkify(state, false)
+      case 0x3C:
+        return autolink(state, false) || html_inline(state, false)
+      case 0x5B:
+        return link(state, false)
+      case 0x5C:
+        return escape(state, false)
+      case 0x60:
+        return backticks(state, false)
+      case 0x7E:
+        return strikethrough.tokenize(state, false)
+      default:
+        return false
     }
   }
 

--- a/src/stream/delta.ts
+++ b/src/stream/delta.ts
@@ -1,0 +1,301 @@
+import type { Token } from '../common/token'
+import type { MarkdownIt } from '../index'
+import type { GlobalMarkdownStateReason } from '../parse/global_state'
+import { countLines } from '../common/utils'
+import { detectGlobalMarkdownState, runWithKnownGlobalMarkdownState } from '../parse/global_state'
+
+export interface DeltaMarkdownStreamOptions {
+  final?: boolean
+}
+
+export interface StreamPatch {
+  tokens: Token[]
+  tokenStart: number
+  tokenDeleteCount: number
+  stableLineEnd: number
+  mode: 'append' | 'tail' | 'full'
+}
+
+export interface DeltaMarkdownStreamStats {
+  fedChars: number
+  committedChars: number
+  committedLines: number
+  pendingChars: number
+  reparsedChars: number
+  fullParses: number
+  localizedParses: number
+  emittedPatches: number
+  lastMode: 'pending' | 'append' | 'tail' | 'full'
+}
+
+function makeStats(): DeltaMarkdownStreamStats {
+  return {
+    fedChars: 0,
+    committedChars: 0,
+    committedLines: 0,
+    pendingChars: 0,
+    reparsedChars: 0,
+    fullParses: 0,
+    localizedParses: 0,
+    emittedPatches: 0,
+    lastMode: 'pending',
+  }
+}
+
+function isBlankLine(src: string, start: number, end: number): boolean {
+  for (let i = start; i < end; i++) {
+    const ch = src.charCodeAt(i)
+    if (ch !== 0x20 && ch !== 0x09 && ch !== 0x0D)
+      return false
+  }
+  return true
+}
+
+function scanFenceLine(src: string, start: number, end: number): { marker: number, length: number } | null {
+  let pos = start
+  while (pos < end) {
+    const ch = src.charCodeAt(pos)
+    if (ch === 0x20 || ch === 0x09)
+      pos++
+    else
+      break
+  }
+
+  const marker = src.charCodeAt(pos)
+  if (marker !== 0x60 && marker !== 0x7E)
+    return null
+
+  let runEnd = pos + 1
+  while (runEnd < end && src.charCodeAt(runEnd) === marker)
+    runEnd++
+
+  const length = runEnd - pos
+  return length >= 3 ? { marker, length } : null
+}
+
+function hasContainerRisk(src: string): boolean {
+  let lineStart = 0
+  while (lineStart < src.length) {
+    let lineEnd = src.indexOf('\n', lineStart)
+    if (lineEnd < 0)
+      lineEnd = src.length
+
+    let pos = lineStart
+    let indent = 0
+    while (pos < lineEnd) {
+      const ch = src.charCodeAt(pos)
+      if (ch === 0x20) {
+        indent++
+        pos++
+        continue
+      }
+      if (ch === 0x09) {
+        indent += 4 - (indent % 4)
+        pos++
+        continue
+      }
+      break
+    }
+
+    if (indent < 4 && pos < lineEnd) {
+      const ch = src.charCodeAt(pos)
+      if (ch === 0x3E)
+        return true
+      if ((ch === 0x2D || ch === 0x2A || ch === 0x2B) && pos + 1 < lineEnd) {
+        const next = src.charCodeAt(pos + 1)
+        if (next === 0x20 || next === 0x09)
+          return true
+      }
+      if (ch >= 0x30 && ch <= 0x39) {
+        let p = pos + 1
+        while (p < lineEnd) {
+          const digit = src.charCodeAt(p)
+          if (digit < 0x30 || digit > 0x39)
+            break
+          p++
+        }
+        if (p < lineEnd && src.charCodeAt(p) === 0x2E && p + 1 < lineEnd) {
+          const next = src.charCodeAt(p + 1)
+          if (next === 0x20 || next === 0x09)
+            return true
+        }
+      }
+    }
+
+    if (lineEnd === src.length)
+      break
+    lineStart = lineEnd + 1
+  }
+
+  return false
+}
+
+function hasDefinitionRisk(src: string): boolean {
+  if (detectGlobalMarkdownState(src))
+    return true
+
+  return src.includes('[')
+}
+
+function findStablePrefixEnd(src: string): number {
+  if (!src)
+    return 0
+
+  let stableEnd = 0
+  let lineStart = 0
+  let fence: { marker: number, length: number } | null = null
+
+  while (lineStart < src.length) {
+    let lineEnd = src.indexOf('\n', lineStart)
+    let lineEndWithNl = lineEnd
+    if (lineEnd < 0) {
+      lineEnd = src.length
+      lineEndWithNl = src.length
+    }
+    else {
+      lineEndWithNl = lineEnd + 1
+    }
+
+    const fenceLine = scanFenceLine(src, lineStart, lineEnd)
+    if (fenceLine) {
+      if (!fence)
+        fence = fenceLine
+      else if (fence.marker === fenceLine.marker && fenceLine.length >= fence.length)
+        fence = null
+    }
+
+    if (!fence && isBlankLine(src, lineStart, lineEnd))
+      stableEnd = lineEndWithNl
+
+    if (lineEndWithNl === src.length)
+      break
+    lineStart = lineEndWithNl
+  }
+
+  if (stableEnd === 0)
+    return 0
+
+  const candidate = src.slice(0, stableEnd)
+  if (hasContainerRisk(candidate) || hasDefinitionRisk(candidate))
+    return 0
+
+  return stableEnd
+}
+
+function appendTokens(out: Token[], tokens: Token[]): void {
+  for (let i = 0; i < tokens.length; i++)
+    out.push(tokens[i])
+}
+
+export class DeltaMarkdownStream {
+  private readonly md: MarkdownIt
+  private readonly env: Record<string, unknown>
+  private committedTokens: Token[] = []
+  private pending = ''
+  private statsState = makeStats()
+  private pendingGlobalReason: GlobalMarkdownStateReason | null = null
+
+  constructor(md: MarkdownIt, env: Record<string, unknown> = {}) {
+    this.md = md
+    this.env = env
+  }
+
+  feed(delta: string, opts: DeltaMarkdownStreamOptions = {}): StreamPatch | null {
+    if (delta) {
+      this.pending += delta
+      this.statsState.fedChars += delta.length
+      this.pendingGlobalReason = this.pendingGlobalReason || detectGlobalMarkdownState(this.pending)
+    }
+
+    return this.flush(opts)
+  }
+
+  flush(opts: DeltaMarkdownStreamOptions = {}): StreamPatch | null {
+    if (!this.pending) {
+      this.statsState.pendingChars = 0
+      return null
+    }
+
+    const final = opts.final === true
+    let stableEnd = final ? this.pending.length : findStablePrefixEnd(this.pending)
+    if (stableEnd <= 0) {
+      this.statsState.pendingChars = this.pending.length
+      this.statsState.lastMode = 'pending'
+      return null
+    }
+
+    if (!final && this.pendingGlobalReason) {
+      this.statsState.pendingChars = this.pending.length
+      this.statsState.lastMode = 'pending'
+      return null
+    }
+
+    if (stableEnd < this.pending.length) {
+      while (stableEnd > 0) {
+        const ch = this.pending.charCodeAt(stableEnd - 1)
+        if (ch === 0x0A || ch === 0x20 || ch === 0x09 || ch === 0x0D)
+          break
+        stableEnd--
+      }
+    }
+
+    const stable = this.pending.slice(0, stableEnd)
+    const reason = this.pendingGlobalReason || detectGlobalMarkdownState(stable)
+    const mode: StreamPatch['mode'] = reason && final && this.committedTokens.length === 0
+      ? 'full'
+      : 'append'
+    const tokens = runWithKnownGlobalMarkdownState(this.env, reason, () => {
+      return this.md.core.parse(stable, this.env, this.md).tokens
+    })
+
+    const tokenStart = mode === 'full' ? 0 : this.committedTokens.length
+    const tokenDeleteCount = mode === 'full' ? this.committedTokens.length : 0
+    if (mode === 'full') {
+      this.committedTokens = tokens.slice()
+      this.statsState.fullParses += 1
+    }
+    else {
+      appendTokens(this.committedTokens, tokens)
+      this.statsState.localizedParses += 1
+    }
+
+    this.pending = this.pending.slice(stableEnd)
+    this.pendingGlobalReason = detectGlobalMarkdownState(this.pending)
+    this.statsState.committedChars += stable.length
+    this.statsState.committedLines += countLines(stable)
+    this.statsState.pendingChars = this.pending.length
+    this.statsState.reparsedChars += stable.length
+    this.statsState.emittedPatches += 1
+    this.statsState.lastMode = mode
+
+    return {
+      tokens,
+      tokenStart,
+      tokenDeleteCount,
+      stableLineEnd: this.statsState.committedLines,
+      mode,
+    }
+  }
+
+  peek(): Token[] {
+    return this.committedTokens
+  }
+
+  stats(): DeltaMarkdownStreamStats {
+    return {
+      ...this.statsState,
+      pendingChars: this.pending.length,
+    }
+  }
+
+  reset(): void {
+    this.committedTokens = []
+    this.pending = ''
+    this.statsState = makeStats()
+    this.pendingGlobalReason = null
+  }
+}
+
+export function createDeltaStream(md: MarkdownIt, env: Record<string, unknown> = {}): DeltaMarkdownStream {
+  return new DeltaMarkdownStream(md, env)
+}

--- a/src/stream/editable.ts
+++ b/src/stream/editable.ts
@@ -3,6 +3,7 @@ import type { MarkdownIt } from '../index'
 import type { GlobalMarkdownStateReason } from '../parse/global_state'
 import { detectGlobalMarkdownState, detectGlobalMarkdownStateFromChunks, getKnownGlobalMarkdownState, resetKnownGlobalMarkdownState, runWithKnownGlobalMarkdownState } from '../parse/global_state'
 import { beginParseDiagnostics, setEditableDiagnostics } from '../parse/strategy_diagnostics'
+import { SegmentIndex } from './indexes'
 import { PieceTable } from './piece_table'
 
 interface SegmentAnchor {
@@ -87,6 +88,7 @@ export class EditableBuffer {
   private statsState: EditableBufferStats
   private globalStateReason: GlobalMarkdownStateReason | null
   private staleGlobalStateReason: GlobalMarkdownStateReason | null = null
+  private segmentIndex = new SegmentIndex()
 
   constructor(md: MarkdownIt, initial = '') {
     this.md = md
@@ -131,6 +133,7 @@ export class EditableBuffer {
     this.staleGlobalStateReason = this.staleGlobalStateReason || this.globalStateReason
     this.source = next
     this.tokens = []
+    this.segmentIndex.clear()
     this.globalStateReason = detectGlobalMarkdownState(text)
     this.statsState = {
       edits: 0,
@@ -226,6 +229,7 @@ export class EditableBuffer {
     this.tokens = runWithKnownGlobalMarkdownState(env, nextReason, () => {
       return this.md.core.parseSource(this.source.view(), env, this.md).tokens
     })
+    this.segmentIndex.rebuild(this.tokens, this.source)
     this.globalStateReason = nextReason
     this.statsState.fullParses += 1
     this.statsState.lastMode = 'full'
@@ -242,6 +246,8 @@ export class EditableBuffer {
     if (anchor.lineStart > 0)
       shiftTokenLines(reparsed, anchor.lineStart)
     appendTokens(this.tokens, reparsed)
+    this.segmentIndex.truncateFromToken(anchor.tokenStart)
+    this.segmentIndex.appendFromTokens(this.tokens, anchor.tokenStart, this.source)
 
     this.statsState.localizedParses += 1
     this.statsState.lastMode = 'localized'
@@ -252,61 +258,18 @@ export class EditableBuffer {
   }
 
   private findAnchorForEditLine(editLine: number): SegmentAnchor | null {
-    const segments = this.collectTopLevelSegments()
-    if (!segments.length)
+    const segment = this.segmentIndex.findByLine(editLine)
+    if (!segment)
       return null
 
-    let segmentIndex = segments.length - 1
-    for (let i = 0; i < segments.length; i++) {
-      const segment = segments[i]
-      if (editLine < segment.lineEnd || editLine <= segment.lineStart) {
-        segmentIndex = i
-        break
-      }
+    const anchor = this.segmentIndex.previous(segment)
+    if (!anchor)
+      return null
+
+    return {
+      tokenStart: anchor.tokenStart,
+      lineStart: anchor.lineStart,
+      lineEnd: anchor.lineEnd,
     }
-
-    const anchorIndex = Math.max(0, segmentIndex - 1)
-    return segments[anchorIndex]
-  }
-
-  private collectTopLevelSegments(): SegmentAnchor[] {
-    const segments: SegmentAnchor[] = []
-    let current: SegmentAnchor | null = null
-
-    const pushCurrent = () => {
-      if (!current)
-        return
-      if (current.lineEnd < current.lineStart)
-        current.lineEnd = current.lineStart
-      segments.push(current)
-      current = null
-    }
-
-    for (let i = 0; i < this.tokens.length; i++) {
-      const token = this.tokens[i]
-      const isSegmentStart = token.level === 0 && token.nesting >= 0
-
-      if (isSegmentStart) {
-        pushCurrent()
-        current = {
-          tokenStart: i,
-          lineStart: token.map?.[0] ?? 0,
-          lineEnd: token.map?.[1] ?? token.map?.[0] ?? 0,
-        }
-      }
-
-      if (!current)
-        continue
-
-      if (token.map) {
-        if (token.map[0] < current.lineStart)
-          current.lineStart = token.map[0]
-        if (token.map[1] > current.lineEnd)
-          current.lineEnd = token.map[1]
-      }
-    }
-
-    pushCurrent()
-    return segments
   }
 }

--- a/src/stream/indexes.ts
+++ b/src/stream/indexes.ts
@@ -1,0 +1,199 @@
+import type { Token } from '../common/token'
+
+export const SEGMENT_FLAG_LIST = 1 << 0
+export const SEGMENT_FLAG_TABLE = 1 << 1
+export const SEGMENT_FLAG_FENCE = 1 << 2
+export const SEGMENT_FLAG_PARAGRAPH = 1 << 3
+
+export interface Segment {
+  tokenStart: number
+  tokenEnd: number
+  lineStart: number
+  lineEnd: number
+  srcOffset: number
+  type: string
+  flags: number
+}
+
+interface LineLookup {
+  offsetOfLine: (line: number) => number
+}
+
+function segmentFlags(type: string): number {
+  switch (type) {
+    case 'bullet_list_open':
+    case 'ordered_list_open':
+      return SEGMENT_FLAG_LIST
+    case 'table_open':
+      return SEGMENT_FLAG_TABLE
+    case 'fence':
+      return SEGMENT_FLAG_FENCE
+    case 'paragraph_open':
+      return SEGMENT_FLAG_PARAGRAPH
+    default:
+      return 0
+  }
+}
+
+export class LineIndex {
+  private newlineOffsets: number[] = []
+  private sourceLength = 0
+
+  reset(src = ''): void {
+    this.newlineOffsets = []
+    this.sourceLength = 0
+    this.append(src, 0)
+  }
+
+  append(delta: string, absoluteStart: number): void {
+    if (!delta)
+      return
+
+    this.sourceLength = absoluteStart + delta.length
+    for (let i = 0; i < delta.length; i++) {
+      if (delta.charCodeAt(i) === 0x0A)
+        this.newlineOffsets.push(absoluteStart + i)
+    }
+  }
+
+  truncate(offset: number): void {
+    const nextLength = Math.max(0, Math.min(offset, this.sourceLength))
+    let lo = 0
+    let hi = this.newlineOffsets.length
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1
+      if (this.newlineOffsets[mid] < nextLength)
+        lo = mid + 1
+      else
+        hi = mid
+    }
+    this.newlineOffsets.length = lo
+    this.sourceLength = nextLength
+  }
+
+  lineOfOffset(offset: number): number {
+    const target = Math.max(0, Math.min(offset, this.sourceLength))
+    let lo = 0
+    let hi = this.newlineOffsets.length
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1
+      if (this.newlineOffsets[mid] < target)
+        lo = mid + 1
+      else
+        hi = mid
+    }
+    return lo
+  }
+
+  offsetOfLine(line: number): number {
+    if (line <= 0)
+      return 0
+
+    const prevNewline = this.newlineOffsets[line - 1]
+    return prevNewline === undefined ? this.sourceLength : prevNewline + 1
+  }
+
+  lineCount(): number {
+    return this.newlineOffsets.length
+  }
+}
+
+export class SegmentIndex {
+  private segments: Segment[] = []
+
+  clear(): void {
+    this.segments.length = 0
+  }
+
+  last(): Segment | null {
+    return this.segments.length ? this.segments[this.segments.length - 1] : null
+  }
+
+  findByLine(line: number): Segment | null {
+    if (!this.segments.length)
+      return null
+
+    let lo = 0
+    let hi = this.segments.length - 1
+    let best = this.segments[hi]
+
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1
+      const segment = this.segments[mid]
+      if (line < segment.lineEnd || line <= segment.lineStart) {
+        best = segment
+        hi = mid - 1
+      }
+      else {
+        lo = mid + 1
+      }
+    }
+
+    return best
+  }
+
+  previous(segment: Segment): Segment | null {
+    const index = this.segments.indexOf(segment)
+    if (index <= 0)
+      return this.segments[0] ?? null
+    return this.segments[index - 1]
+  }
+
+  truncateFromToken(tokenStart: number): void {
+    let nextLength = this.segments.length
+    while (nextLength > 0 && this.segments[nextLength - 1].tokenStart >= tokenStart)
+      nextLength--
+    this.segments.length = nextLength
+  }
+
+  rebuild(tokens: Token[], lineIndex: LineLookup): void {
+    this.clear()
+    this.appendFromTokens(tokens, 0, lineIndex)
+  }
+
+  appendFromTokens(tokens: Token[], tokenStart: number, lineIndex: LineLookup): void {
+    let current: Segment | null = null
+
+    const pushCurrent = (tokenEnd: number) => {
+      if (!current)
+        return
+      if (current.lineEnd < current.lineStart)
+        current.lineEnd = current.lineStart
+      current.tokenEnd = tokenEnd
+      current.srcOffset = lineIndex.offsetOfLine(current.lineStart)
+      this.segments.push(current)
+      current = null
+    }
+
+    for (let i = tokenStart; i < tokens.length; i++) {
+      const token = tokens[i]
+      const isSegmentStart = token.level === 0 && token.nesting >= 0
+
+      if (isSegmentStart) {
+        pushCurrent(i)
+        const lineStart = token.map?.[0] ?? 0
+        current = {
+          tokenStart: i,
+          tokenEnd: tokens.length,
+          lineStart,
+          lineEnd: token.map?.[1] ?? lineStart,
+          srcOffset: lineIndex.offsetOfLine(lineStart),
+          type: token.type,
+          flags: segmentFlags(token.type),
+        }
+      }
+
+      if (!current)
+        continue
+
+      if (token.map) {
+        if (token.map[0] < current.lineStart)
+          current.lineStart = token.map[0]
+        if (token.map[1] > current.lineEnd)
+          current.lineEnd = token.map[1]
+      }
+    }
+
+    pushCurrent(tokens.length)
+  }
+}

--- a/src/stream/parser.ts
+++ b/src/stream/parser.ts
@@ -7,6 +7,7 @@ import { detectGlobalMarkdownState, getKnownGlobalMarkdownState, resetKnownGloba
 import { beginParseDiagnostics, getParseDiagnostics, setStrategyDiagnostics } from '../parse/strategy_diagnostics'
 import { recommendStreamChunkStrategy } from '../support/chunk_recommend'
 import { chunkedParse } from './chunked'
+import { LineIndex, SegmentIndex } from './indexes'
 import { getAutoUnboundedDecision, parseStringUnbounded, shouldAutoUseUnbounded } from './unbounded'
 
 interface StreamCache {
@@ -17,6 +18,8 @@ interface StreamCache {
   lineCount?: number
   lastSegment?: StreamSegment | null
   globalStateReason?: GlobalMarkdownStateReason | null
+  lineIndex?: LineIndex
+  segmentIndex?: SegmentIndex
 }
 
 interface StreamSegment {
@@ -28,6 +31,54 @@ interface StreamSegment {
 }
 
 const EMPTY_TOKENS: Token[] = []
+
+function attrsEqual(a?: [string, string][] | null, b?: [string, string][] | null): boolean {
+  if (!a && !b)
+    return true
+  if (!a || !b || a.length !== b.length)
+    return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i][0] !== b[i][0] || a[i][1] !== b[i][1])
+      return false
+  }
+  return true
+}
+
+function tokenSignature(t: Token): string {
+  return `${t.type}|${t.tag}|${t.nesting}|${t.level}|${t.markup}|${t.info}|${t.content.length}`
+}
+
+function childrenEqual(a?: Token[] | null, b?: Token[] | null): boolean {
+  if (!a && !b)
+    return true
+  if (!a || !b || a.length !== b.length)
+    return false
+  for (let i = 0; i < a.length; i++) {
+    if (!tokenEquals(a[i], b[i]))
+      return false
+  }
+  return true
+}
+
+function tokenEquals(x: Token | undefined, y: Token | undefined): boolean {
+  if (!x || !y)
+    return false
+  if (tokenSignature(x) !== tokenSignature(y))
+    return false
+  const xMap = x.map
+  const yMap = y.map
+  if (!!xMap !== !!yMap)
+    return false
+  if (xMap && yMap && (xMap[0] !== yMap[0] || xMap[1] !== yMap[1]))
+    return false
+  if (x.block !== y.block || x.hidden !== y.hidden)
+    return false
+  if (!attrsEqual(x.attrs, y.attrs))
+    return false
+  if (!childrenEqual(x.children, y.children))
+    return false
+  return x.content === y.content
+}
 
 export interface StreamStats {
   total: number
@@ -547,56 +598,6 @@ export class StreamParser {
         const a = appendedState.tokens
         const maxCheck = Math.min(cachedTail.length, a.length)
 
-        function attrsEqual(a?: [string, string][] | null, b?: [string, string][] | null) {
-          if (!a && !b)
-            return true
-          if (!a || !b || a.length !== b.length)
-            return false
-          for (let i = 0; i < a.length; i++) {
-            if (a[i][0] !== b[i][0] || a[i][1] !== b[i][1])
-              return false
-          }
-          return true
-        }
-
-        function childrenEqual(a?: any[] | null, b?: any[] | null) {
-          if (!a && !b)
-            return true
-          if (!a || !b || a.length !== b.length)
-            return false
-          for (let i = 0; i < a.length; i++) {
-            if (!tokenEquals(a[i], b[i]))
-              return false
-          }
-          return true
-        }
-
-        function tokenEquals(x: any, y: any) {
-          if (!x || !y)
-            return false
-          if (x.type !== y.type)
-            return false
-          const xMap = x.map
-          const yMap = y.map
-          if (!!xMap !== !!yMap)
-            return false
-          if (xMap && yMap && (xMap[0] !== yMap[0] || xMap[1] !== yMap[1]))
-            return false
-          if (x.tag !== y.tag || x.nesting !== y.nesting)
-            return false
-          if (x.markup !== y.markup || x.info !== y.info)
-            return false
-          if (x.block !== y.block || x.hidden !== y.hidden)
-            return false
-          if (!attrsEqual(x.attrs, y.attrs))
-            return false
-          if (!childrenEqual(x.children, y.children))
-            return false
-          if (x.type === 'inline')
-            return (x.content || '') === (y.content || '')
-          return (x.content || '') === (y.content || '')
-        }
-
         // Debug output suppressed in CI
         let dup = 0
         // Try longest prefix match
@@ -627,27 +628,18 @@ export class StreamParser {
       }
 
       // Update cache with new src and line count
+      const oldSrcLength = cached.src.length
+      const lineIndex = this.ensureLineIndex(cached)
       cached.src = src
       cached.globalStateReason = detectGlobalMarkdownState(src)
       const appendedLines = appendedLineCount ?? countLines(appended)
       cached.lineCount = cachedLineCount + appendedLines
+      lineIndex.append(appended, oldSrcLength)
       if (cached.tokens.length > appendStart) {
-        const appendedLastSegment = this.getLastSegment(cached.tokens.slice(appendStart), src)
-        if (appendedLastSegment) {
-          cached.lastSegment = {
-            tokenStart: appendStart + appendedLastSegment.tokenStart,
-            tokenEnd: appendStart + appendedLastSegment.tokenEnd,
-            lineStart: appendedLastSegment.lineStart,
-            lineEnd: appendedLastSegment.lineEnd,
-            srcOffset: appendedLastSegment.srcOffset,
-          }
-        }
-        else {
-          cached.lastSegment = undefined
-        }
-      }
-      else {
-        cached.lastSegment = undefined
+        const segmentIndex = this.ensureSegmentIndex(cached)
+        segmentIndex.truncateFromToken(appendStart)
+        segmentIndex.appendFromTokens(cached.tokens, appendStart, lineIndex)
+        cached.lastSegment = segmentIndex.last()
       }
 
       this.stats.total += 1
@@ -936,7 +928,6 @@ export class StreamParser {
 
     try {
       const tailState = this.core.parse(nextTail, env, md)
-      const localLastSegment = this.getLastSegment(tailState.tokens, nextTail)
       if (lastSegment.lineStart > 0)
         this.shiftTokenLines(tailState.tokens, lastSegment.lineStart)
 
@@ -945,19 +936,7 @@ export class StreamParser {
       cached.globalStateReason = detectGlobalMarkdownState(src)
       cached.tokens.length = lastSegment.tokenStart
       this.appendTokens(cached.tokens, tailState.tokens)
-      cached.lineCount = countLines(src)
-      if (localLastSegment) {
-        cached.lastSegment = {
-          tokenStart: lastSegment.tokenStart + localLastSegment.tokenStart,
-          tokenEnd: lastSegment.tokenStart + localLastSegment.tokenEnd,
-          lineStart: lastSegment.lineStart + localLastSegment.lineStart,
-          lineEnd: lastSegment.lineStart + localLastSegment.lineEnd,
-          srcOffset: lastSegment.srcOffset + localLastSegment.srcOffset,
-        }
-      }
-      else {
-        cached.lastSegment = null
-      }
+      this.updateCacheIndexesFrom(cached, lastSegment.tokenStart, lastSegment.srcOffset, nextTail)
       return cached.tokens
     }
     catch {
@@ -1046,26 +1025,65 @@ export class StreamParser {
 
   private updateCacheLineCount(cache: StreamCache, lineCount?: number): void {
     cache.lineCount = lineCount ?? countLines(cache.src)
-    cache.lastSegment = undefined
+    this.rebuildCacheIndexes(cache)
   }
 
   private ensureLastSegment(cache: StreamCache): StreamSegment | null {
     if (cache.lastSegment !== undefined)
       return cache.lastSegment
 
-    cache.lastSegment = this.getLastSegment(cache.tokens, cache.src)
+    cache.lastSegment = this.ensureSegmentIndex(cache).last()
     return cache.lastSegment
   }
 
-  private getLastSegment(tokens: Token[], src: string): StreamSegment | null {
-    if (tokens.length === 0)
+  private ensureLineIndex(cache: StreamCache): LineIndex {
+    if (!cache.lineIndex) {
+      cache.lineIndex = new LineIndex()
+      cache.lineIndex.reset(cache.src)
+    }
+    return cache.lineIndex
+  }
+
+  private ensureSegmentIndex(cache: StreamCache): SegmentIndex {
+    if (!cache.segmentIndex) {
+      cache.segmentIndex = new SegmentIndex()
+      cache.segmentIndex.rebuild(cache.tokens, this.ensureLineIndex(cache))
+    }
+    return cache.segmentIndex
+  }
+
+  private rebuildCacheIndexes(cache: StreamCache): void {
+    const lineIndex = cache.lineIndex ?? new LineIndex()
+    lineIndex.reset(cache.src)
+    cache.lineIndex = lineIndex
+
+    const segmentIndex = cache.segmentIndex ?? new SegmentIndex()
+    segmentIndex.rebuild(cache.tokens, lineIndex)
+    cache.segmentIndex = segmentIndex
+    cache.lastSegment = segmentIndex.last()
+  }
+
+  private updateCacheIndexesFrom(cache: StreamCache, tokenStart: number, srcOffset: number, nextTail: string): void {
+    const lineIndex = this.ensureLineIndex(cache)
+    lineIndex.truncate(srcOffset)
+    lineIndex.append(nextTail, srcOffset)
+    cache.lineCount = lineIndex.lineCount()
+
+    const segmentIndex = this.ensureSegmentIndex(cache)
+    segmentIndex.truncateFromToken(tokenStart)
+    segmentIndex.appendFromTokens(cache.tokens, tokenStart, lineIndex)
+    cache.lastSegment = segmentIndex.last()
+  }
+
+  private getLastSegment(tokens: Token[], src: string, start = 0, end = tokens.length, lineIndex?: LineIndex): StreamSegment | null {
+    if (end <= start)
       return null
 
     let lineStart = Number.POSITIVE_INFINITY
     let lineEnd = -1
     let depth = 0
 
-    for (let i = tokens.length - 1; i >= 0; i--) {
+    for (let i = end - 1; i >= start; i--) {
       const token = tokens[i]
       if (token.map) {
         if (token.map[0] < lineStart)
@@ -1090,10 +1108,10 @@ export class StreamParser {
             : (token.map?.[1] ?? resolvedStart)
           return {
             tokenStart: i,
-            tokenEnd: tokens.length,
+            tokenEnd: end,
             lineStart: resolvedStart,
             lineEnd: resolvedEnd,
-            srcOffset: this.getLineStartOffset(src, resolvedStart),
+            srcOffset: lineIndex ? lineIndex.offsetOfLine(resolvedStart) : this.getLineStartOffset(src, resolvedStart),
           }
         }
         continue
@@ -1108,10 +1126,10 @@ export class StreamParser {
           : (token.map?.[1] ?? resolvedStart)
         return {
           tokenStart: i,
-          tokenEnd: tokens.length,
+          tokenEnd: end,
           lineStart: resolvedStart,
           lineEnd: resolvedEnd,
-          srcOffset: this.getLineStartOffset(src, resolvedStart),
+          srcOffset: lineIndex ? lineIndex.offsetOfLine(resolvedStart) : this.getLineStartOffset(src, resolvedStart),
         }
       }
     }
@@ -1235,20 +1253,20 @@ export class StreamParser {
       this.setListParagraphVisibility(inserted, 0, inserted.length, listOpen.level, false)
     }
 
+    const oldSrcLength = cached.src.length
+    const lineIndex = this.ensureLineIndex(cached)
     cached.tokens.splice(cached.tokens.length - 1, 0, ...inserted)
     cached.src = src
     cached.env = env
     cached.globalStateReason = detectGlobalMarkdownState(src)
-    cached.lineCount = countLines(src)
+    lineIndex.append(appended, oldSrcLength)
+    cached.lineCount = lineIndex.lineCount()
     if (listOpen.map)
       listOpen.map[1] = this.getDocLineCount(src)
-    cached.lastSegment = {
-      tokenStart: lastSegment.tokenStart,
-      tokenEnd: cached.tokens.length,
-      lineStart: lastSegment.lineStart,
-      lineEnd: this.getDocLineCount(src),
-      srcOffset: lastSegment.srcOffset,
-    }
+    const segmentIndex = this.ensureSegmentIndex(cached)
+    segmentIndex.truncateFromToken(lastSegment.tokenStart)
+    segmentIndex.appendFromTokens(cached.tokens, lastSegment.tokenStart, lineIndex)
+    cached.lastSegment = segmentIndex.last()
     return cached.tokens
   }
 
@@ -1306,11 +1324,14 @@ export class StreamParser {
     const insertAt = cachedSection.tbodyCloseIndex >= 0
       ? cachedSection.tbodyCloseIndex
       : cachedSection.tableCloseIndex
+    const oldSrcLength = cached.src.length
+    const lineIndex = this.ensureLineIndex(cached)
     cached.tokens.splice(insertAt, 0, ...inserted)
     cached.src = src
     cached.env = env
     cached.globalStateReason = detectGlobalMarkdownState(src)
-    cached.lineCount = countLines(src)
+    lineIndex.append(appended, oldSrcLength)
+    cached.lineCount = lineIndex.lineCount()
 
     const nextDocLineCount = this.getDocLineCount(src)
     if (tableOpen.map)
@@ -1321,13 +1342,10 @@ export class StreamParser {
         tbodyOpen.map[1] = nextDocLineCount
     }
 
-    cached.lastSegment = {
-      tokenStart: lastSegment.tokenStart,
-      tokenEnd: cached.tokens.length,
-      lineStart: lastSegment.lineStart,
-      lineEnd: nextDocLineCount,
-      srcOffset: lastSegment.srcOffset,
-    }
+    const segmentIndex = this.ensureSegmentIndex(cached)
+    segmentIndex.truncateFromToken(lastSegment.tokenStart)
+    segmentIndex.appendFromTokens(cached.tokens, lastSegment.tokenStart, lineIndex)
+    cached.lastSegment = segmentIndex.last()
     return cached.tokens
   }
 
@@ -1513,8 +1531,9 @@ export class StreamParser {
     if (offset === 0)
       return
 
-    // Use iterative approach with a stack to avoid recursion overhead
-    const stack: Token[] = [...tokens]
+    const stack: Token[] = []
+    for (let i = tokens.length - 1; i >= 0; i--)
+      stack.push(tokens[i])
 
     while (stack.length > 0) {
       const token = stack.pop()!

--- a/src/stream/unbounded.ts
+++ b/src/stream/unbounded.ts
@@ -96,6 +96,73 @@ function estimateLines(src: string): number {
   return countLines(src) + (src.charCodeAt(src.length - 1) === 0x0A ? 0 : 1)
 }
 
+class PendingChunks {
+  private chunks: string[] = []
+  private lineBreaks = 0
+  private lastChar = -1
+  length = 0
+
+  push(chunk: string): void {
+    if (!chunk)
+      return
+
+    this.chunks.push(chunk)
+    this.length += chunk.length
+    this.lastChar = chunk.charCodeAt(chunk.length - 1)
+    this.lineBreaks += countLines(chunk)
+  }
+
+  clear(): void {
+    this.chunks.length = 0
+    this.lineBreaks = 0
+    this.lastChar = -1
+    this.length = 0
+  }
+
+  toString(): string {
+    if (this.chunks.length === 0)
+      return ''
+    if (this.chunks.length === 1)
+      return this.chunks[0]
+
+    const text = this.chunks.join('')
+    this.chunks = [text]
+    return text
+  }
+
+  consume(chars: number): void {
+    if (chars <= 0)
+      return
+    if (chars >= this.length) {
+      this.clear()
+      return
+    }
+
+    let remaining = chars
+    while (remaining > 0 && this.chunks.length) {
+      const first = this.chunks[0]
+      if (remaining < first.length) {
+        this.chunks[0] = first.slice(remaining)
+        break
+      }
+      remaining -= first.length
+      this.chunks.shift()
+    }
+
+    const text = this.chunks.length === 1 ? this.chunks[0] : this.chunks.join('')
+    this.chunks = text ? [text] : []
+    this.length = text.length
+    this.lineBreaks = countLines(text)
+    this.lastChar = text.length ? text.charCodeAt(text.length - 1) : -1
+  }
+
+  estimateLines(): number {
+    if (this.length === 0)
+      return 0
+    return this.lineBreaks + (this.lastChar === 0x0A ? 0 : 1)
+  }
+}
+
 function isBlankLine(src: string, start: number, end: number): boolean {
   for (let i = start; i < end; i++) {
     const ch = src.charCodeAt(i)
@@ -226,7 +293,7 @@ function resolveWindow(md: MarkdownIt, totalChars: number, totalLines: number, o
 export class UnboundedBuffer {
   private readonly md: MarkdownIt
   private readonly options: UnboundedBufferOptions
-  private pending = ''
+  private pending = new PendingChunks()
   private tokens: Token[] = []
   private committedChars = 0
   private committedLines = 0
@@ -246,22 +313,23 @@ export class UnboundedBuffer {
   feed(chunk: string): void {
     if (!chunk)
       return
-    this.pending += chunk
+    this.pending.push(chunk)
     this.fedChunks += 1
   }
 
   flushAvailable(env: Record<string, unknown> = {}): Token[] | null {
-    if (!this.pending)
+    if (this.pending.length === 0)
       return null
 
     const window = this.resolveWindow()
-    const pendingLines = estimateLines(this.pending)
+    const pendingLines = this.pending.estimateLines()
     if (this.pending.length < window.holdBelowChars && pendingLines < window.holdBelowLines) {
       this.updateEnvDiagnostics(env, window, pendingLines)
       return null
     }
 
-    const ranges = splitIntoChunkRanges(this.pending, {
+    const pendingText = this.pending.toString()
+    const ranges = splitIntoChunkRanges(pendingText, {
       maxChunkChars: window.maxChunkChars,
       maxChunkLines: window.maxChunkLines,
       fenceAware: window.fenceAware,
@@ -273,28 +341,29 @@ export class UnboundedBuffer {
       return null
     }
 
-    if (hasUnsafeChunkBoundary(this.pending, ranges, { rangesCoverWholeSource: false })) {
+    if (hasUnsafeChunkBoundary(pendingText, ranges, { rangesCoverWholeSource: false })) {
       this.updateEnvDiagnostics(env, window, pendingLines)
       return null
     }
 
-    const consumed = this.commitRanges(ranges, env)
-    this.pending = this.pending.slice(consumed)
-    this.updateEnvDiagnostics(env, window, estimateLines(this.pending))
+    const consumed = this.commitRanges(pendingText, ranges, env)
+    this.pending.consume(consumed)
+    this.updateEnvDiagnostics(env, window, this.pending.estimateLines())
     return this.tokens
   }
 
   flushIfBoundary(env: Record<string, unknown> = {}): Token[] | null {
-    if (!this.pending)
+    if (this.pending.length === 0)
       return null
 
     const window = this.resolveWindow()
-    if (!endsAtBlankBoundary(this.pending, window.fenceAware)) {
-      this.updateEnvDiagnostics(env, window, estimateLines(this.pending))
+    const pendingText = this.pending.toString()
+    if (!endsAtBlankBoundary(pendingText, window.fenceAware)) {
+      this.updateEnvDiagnostics(env, window, this.pending.estimateLines())
       return null
     }
 
-    const ranges = splitIntoChunkRanges(this.pending, {
+    const ranges = splitIntoChunkRanges(pendingText, {
       maxChunkChars: window.maxChunkChars,
       maxChunkLines: window.maxChunkLines,
       fenceAware: window.fenceAware,
@@ -302,22 +371,22 @@ export class UnboundedBuffer {
     }, true)
 
     if (!ranges.length) {
-      this.updateEnvDiagnostics(env, window, estimateLines(this.pending))
+      this.updateEnvDiagnostics(env, window, this.pending.estimateLines())
       return null
     }
 
-    const rangesToCommit = hasUnsafeChunkBoundary(this.pending, ranges, { rangesCoverWholeSource: true })
-      ? [{ start: 0, end: this.pending.length, lineCount: estimateLines(this.pending) }]
+    const rangesToCommit = hasUnsafeChunkBoundary(pendingText, ranges, { rangesCoverWholeSource: true })
+      ? [{ start: 0, end: pendingText.length, lineCount: estimateLines(pendingText) }]
       : ranges
 
-    this.commitRanges(rangesToCommit, env)
-    this.pending = ''
+    this.commitRanges(pendingText, rangesToCommit, env)
+    this.pending.clear()
     this.updateEnvDiagnostics(env, window, 0)
     return this.tokens
   }
 
   flushForce(env: Record<string, unknown> = {}): Token[] {
-    if (!this.pending) {
+    if (this.pending.length === 0) {
       this.prepareGlobalStateEnv(env, '')
       const window = this.resolveWindow()
       this.updateEnvDiagnostics(env, window, 0)
@@ -325,7 +394,8 @@ export class UnboundedBuffer {
     }
 
     const window = this.resolveWindow()
-    const ranges = splitIntoChunkRanges(this.pending, {
+    const pendingText = this.pending.toString()
+    const ranges = splitIntoChunkRanges(pendingText, {
       maxChunkChars: window.maxChunkChars,
       maxChunkLines: window.maxChunkLines,
       fenceAware: window.fenceAware,
@@ -333,12 +403,12 @@ export class UnboundedBuffer {
     }, true)
 
     if (ranges.length) {
-      const rangesToCommit = hasUnsafeChunkBoundary(this.pending, ranges, { rangesCoverWholeSource: true })
-        ? [{ start: 0, end: this.pending.length, lineCount: estimateLines(this.pending) }]
+      const rangesToCommit = hasUnsafeChunkBoundary(pendingText, ranges, { rangesCoverWholeSource: true })
+        ? [{ start: 0, end: pendingText.length, lineCount: estimateLines(pendingText) }]
         : ranges
 
-      this.commitRanges(rangesToCommit, env)
-      this.pending = ''
+      this.commitRanges(pendingText, rangesToCommit, env)
+      this.pending.clear()
     }
 
     this.updateEnvDiagnostics(env, window, 0)
@@ -346,7 +416,7 @@ export class UnboundedBuffer {
   }
 
   reset(): void {
-    this.pending = ''
+    this.pending.clear()
     this.tokens = []
     this.committedChars = 0
     this.committedLines = 0
@@ -361,7 +431,7 @@ export class UnboundedBuffer {
   }
 
   pendingText(): string {
-    return this.pending
+    return this.pending.toString()
   }
 
   stats(): UnboundedBufferStats {
@@ -372,14 +442,14 @@ export class UnboundedBuffer {
       committedChars: this.committedChars,
       committedLines: this.committedLines,
       pendingChars: this.pending.length,
-      pendingLines: estimateLines(this.pending),
+      pendingLines: this.pending.estimateLines(),
       retainedTokens: this.options.retainTokens !== false,
     }
   }
 
   private resolveWindow(): ResolvedWindow {
     const totalChars = this.committedChars + this.pending.length
-    const totalLines = this.committedLines + estimateLines(this.pending)
+    const totalLines = this.committedLines + this.pending.estimateLines()
     return resolveWindow(this.md, totalChars, totalLines, this.options)
   }
 
@@ -403,17 +473,17 @@ export class UnboundedBuffer {
     this.markedGlobalStateReason = reason
   }
 
-  private commitRanges(ranges: Array<{ start: number, end: number, lineCount: number }>, env: Record<string, unknown>): number {
+  private commitRanges(pendingText: string, ranges: Array<{ start: number, end: number, lineCount: number }>, env: Record<string, unknown>): number {
     if (!ranges.length)
       return 0
 
-    this.prepareGlobalStateEnv(env, this.pending)
+    this.prepareGlobalStateEnv(env, pendingText)
 
     let consumed = 0
     try {
       for (let i = 0; i < ranges.length; i++) {
         const range = ranges[i]
-        const src = this.pending.slice(range.start, range.end)
+        const src = pendingText.slice(range.start, range.end)
         const state = this.md.core.parse(src, env, this.md)
         const nextTokens = state.tokens
         const startOffset = this.committedChars

--- a/test/parse/inline-default-dispatch.test.ts
+++ b/test/parse/inline-default-dispatch.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import MarkdownIt from '../../src'
+
+describe('inline default dispatch fast path', () => {
+  it('keeps render parity with the generic rule loop', () => {
+    const cases = [
+      'plain text with [brackets] but no link',
+      '[x][ref]\n\n[ref]: https://example.com',
+      '**bold** and [link](https://example.com)',
+      '`code` <https://example.com> &amp;',
+      'escaped \\* marker and soft\nbreak',
+      '![alt](https://example.com/a.png "title")',
+    ]
+
+    for (const src of cases) {
+      const fast = MarkdownIt()
+      const generic = MarkdownIt()
+      generic.inline.ruler.push('noop_fallback_rule', () => false)
+
+      expect(fast.render(src)).toBe(generic.render(src))
+    }
+  })
+
+  it('handles option-gated inline rules', () => {
+    const html = '<span data-x="1">ok</span>'
+    const htmlGeneric = MarkdownIt({ html: true })
+    htmlGeneric.inline.ruler.push('noop_fallback_rule', () => false)
+    expect(MarkdownIt({ html: true }).render(html))
+      .toBe(htmlGeneric.render(html))
+
+    const linkified = 'Visit https://example.com/path.'
+    const linkifyGeneric = MarkdownIt({ linkify: true })
+    linkifyGeneric.inline.ruler.push('noop_fallback_rule', () => false)
+    expect(MarkdownIt({ linkify: true }).render(linkified))
+      .toBe(linkifyGeneric.render(linkified))
+    expect(MarkdownIt({ linkify: true }).render(linkified))
+      .toContain('href="https://example.com/path"')
+  })
+})

--- a/test/stream/ai-delta-stream.test.ts
+++ b/test/stream/ai-delta-stream.test.ts
@@ -1,0 +1,115 @@
+import type { Token } from '../../src/common/token'
+import { describe, expect, it } from 'vitest'
+import MarkdownIt from '../../src'
+import { createDeltaStream, type StreamPatch } from '../../src/experimental'
+
+function applyPatch(tokens: Token[], patch: StreamPatch): Token[] {
+  tokens.splice(patch.tokenStart, patch.tokenDeleteCount, ...patch.tokens)
+  return tokens
+}
+
+function splitWithSeed(src: string, seed: number): string[] {
+  const chunks: string[] = []
+  let pos = 0
+  let state = seed
+  while (pos < src.length) {
+    state = (state * 1664525 + 1013904223) >>> 0
+    const size = 1 + (state % 17)
+    chunks.push(src.slice(pos, pos + size))
+    pos += size
+  }
+  return chunks
+}
+
+function render(md: ReturnType<typeof MarkdownIt>, tokens: Token[]): string {
+  return md.renderer.render(tokens, md.options, {})
+}
+
+describe('AI delta stream', () => {
+  it('matches full render after arbitrary chunk splits', () => {
+    const src = [
+      '# Title',
+      '',
+      'Intro paragraph with **bold** text and `code`.',
+      '',
+      '```ts',
+      'const value = 1',
+      '```',
+      '',
+      '| name | value |',
+      '| ---- | ----- |',
+      '| a | b |',
+      '',
+      '- held until final',
+      '- because lists can continue after blank lines',
+      '',
+    ].join('\n')
+
+    for (const seed of [1, 2, 3, 42, 999]) {
+      const md = MarkdownIt({ stream: true })
+      const stream = createDeltaStream(md)
+      const tokens: Token[] = []
+
+      for (const delta of splitWithSeed(src, seed)) {
+        const patch = stream.feed(delta)
+        if (patch)
+          applyPatch(tokens, patch)
+      }
+
+      const finalPatch = stream.flush({ final: true })
+      if (finalPatch)
+        applyPatch(tokens, finalPatch)
+
+      expect(render(md, tokens)).toBe(md.render(src))
+      expect(render(md, stream.peek())).toBe(md.render(src))
+    }
+  })
+
+  it('does not flush unsafe reference-definition prefixes early', () => {
+    const src = '[x][ref]\n\n[ref]: https://example.com\n\n'
+    const md = MarkdownIt({ stream: true })
+    const stream = md.stream.createDelta()
+    const tokens: Token[] = []
+
+    for (const delta of ['[x]', '[ref]\n\n', '[ref]: ', 'https://example.com\n\n']) {
+      const patch = stream.feed(delta)
+      expect(patch).toBeNull()
+    }
+
+    const finalPatch = stream.flush({ final: true })
+    expect(finalPatch).not.toBeNull()
+    applyPatch(tokens, finalPatch!)
+
+    expect(render(md, tokens)).toBe(md.render(src))
+    expect(render(md, tokens)).toContain('href="https://example.com"')
+    expect(stream.stats().lastMode).toBe('full')
+  })
+
+  it('emits append patches for stable plain paragraph boundaries', () => {
+    const md = MarkdownIt({ stream: true })
+    const stream = createDeltaStream(md)
+    const tokens: Token[] = []
+
+    const first = stream.feed('First paragraph.\n\n')
+    expect(first).toMatchObject({
+      tokenStart: 0,
+      tokenDeleteCount: 0,
+      mode: 'append',
+    })
+    applyPatch(tokens, first!)
+
+    expect(stream.feed('Second paragraph')).toBeNull()
+
+    const finalPatch = stream.flush({ final: true })
+    expect(finalPatch).toMatchObject({
+      tokenStart: tokens.length,
+      tokenDeleteCount: 0,
+      mode: 'append',
+    })
+    applyPatch(tokens, finalPatch!)
+
+    expect(render(md, tokens)).toBe(md.render('First paragraph.\n\nSecond paragraph'))
+    expect(stream.stats().localizedParses).toBe(2)
+    expect(stream.stats().fullParses).toBe(0)
+  })
+})

--- a/test/types/plugin-authoring.ts
+++ b/test/types/plugin-authoring.ts
@@ -7,8 +7,8 @@ import MarkdownIt, {
   type RendererOptions,
 } from 'markdown-it-ts'
 import { ParserCore } from 'markdown-it-ts/core'
-import { chunkedParse, StreamBuffer } from 'markdown-it-ts/experimental'
-import type { StreamStats } from 'markdown-it-ts/experimental'
+import { chunkedParse, createDeltaStream, StreamBuffer } from 'markdown-it-ts/experimental'
+import type { DeltaMarkdownStreamStats, StreamPatch, StreamStats } from 'markdown-it-ts/experimental'
 import type { RendererRule } from 'markdown-it-ts/render/renderer'
 
 // @ts-expect-error Experimental helpers must stay out of the stable root entry.
@@ -122,6 +122,9 @@ typedMetaToken.meta = { other: 'field' }
 const streamBuffer = new StreamBuffer(typedMd)
 streamBuffer.feed('# Title\n\n')
 const streamStats: StreamStats = typedMd.stream.stats()
+const deltaStream = createDeltaStream(typedMd)
+const streamPatch: StreamPatch | null = typedMd.stream.createDelta().feed('# Title\n\n')
+const deltaStats: DeltaMarkdownStreamStats = deltaStream.stats()
 
 const chunkedTokens: Token[] = chunkedParse(typedMd, '# Title\n\nBody', env)
 const coreTokens: Token[] = new ParserCore().parse('# Core').tokens
@@ -140,5 +143,7 @@ void mdWithNamespacedExperimentalOptions
 void typedMetaToken
 void streamBuffer
 void streamStats
+void streamPatch
+void deltaStats
 void chunkedTokens
 void coreTokens


### PR DESCRIPTION
## Summary
- add an experimental delta-native Markdown stream API with patch output and stats
- add reusable line/segment indexes for stream tail reparses and editable buffer anchors
- add default inline dispatch fast path, unbounded pending chunk storage, and StateBlock line-marker preallocation
- add AI delta stream correctness tests and a perf:ai-stream script

## Verification
- pnpm test -- --run
- pnpm run test:types
- pnpm run build
- pnpm run lint
- node scripts/perf-ai-stream-delta.mjs